### PR TITLE
Feat: Add Backend API- Return Study ID list by PatientID

### DIFF
--- a/server/DSMP/src/main/java/com/knuipalab/dsmp/controller/dicom/DicomController.java
+++ b/server/DSMP/src/main/java/com/knuipalab/dsmp/controller/dicom/DicomController.java
@@ -1,13 +1,73 @@
 package com.knuipalab.dsmp.controller.dicom;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import org.springframework.http.*;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.client.RequestCallback;
+import org.springframework.web.client.ResponseExtractor;
+import org.springframework.web.client.RestTemplate;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.*;
 
 @Controller
 public class DicomController {
 
-    @GetMapping("/Dicom/{id}")
+    @GetMapping("/api/dicom/{id}")
     public String downloadDicom(@PathVariable String id){
         return "redirect:http://orthanc:8042/instances/" + id + "/file";
+    }
+
+    @GetMapping("/api/patient/{id}/dicom")
+    public String downloadPatientDicom(@PathVariable String id, HttpServletResponse httpResponse) throws IOException{
+//        String request_URL = "http://localhost:8042/tools/find";
+        String request_URL = "http://orthanc:8042/tools/find";
+
+        System.out.println("call GET /api/dicom/patient/{id}");
+
+        RestTemplate restTemplate = new RestTemplate();
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        HashMap<String,Object> param = new HashMap<>();
+        JsonNode query = objectMapper.readTree("{\"PatientID\":\"" + id + "\"}");
+        param.put("Expand", true);
+        param.put("Full", true);
+        param.put("Level", "Study");
+        param.put("Query", query);
+
+        // header setting
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        // post api call
+        HttpEntity<Map<String,Object>> requestEntity = new HttpEntity<>(param, headers);
+        ResponseEntity<String> response = restTemplate.postForEntity(request_URL, requestEntity, String.class);
+
+        System.out.println("-----------Response Result------------");
+        JsonNode jsonNode;
+        try {
+            jsonNode = objectMapper.readTree(response.getBody());
+        }
+        catch(Exception ex){
+            System.err.println("Error get Response");
+            jsonNode = objectMapper.readTree(response.toString());
+        }
+        System.out.println(response.toString());
+
+        ArrayNode arrayNode = (ArrayNode) jsonNode;
+        Iterator<JsonNode> itr = arrayNode.elements();
+        String patientId = "";
+        while( itr.hasNext() ) {
+            patientId = itr.next().get("ParentPatient").asText();
+        }
+        System.out.println(patientId);
+
+        return "redirect:http://localhost:8042/patients/" + patientId + "/archive";
     }
 }

--- a/server/DSMP/src/main/java/com/knuipalab/dsmp/controller/dicom/api/DicomApiController.java
+++ b/server/DSMP/src/main/java/com/knuipalab/dsmp/controller/dicom/api/DicomApiController.java
@@ -2,12 +2,14 @@ package com.knuipalab.dsmp.controller.dicom.api;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.*;
 
 @RestController
 public class DicomApiController {
@@ -62,6 +64,87 @@ public class DicomApiController {
         System.out.println(response.toString());
 
         return response.toString();
+    }
+
+    @GetMapping("/api/dicom/{id}/patient")
+    public JsonNode getPatientInfo(@PathVariable String id){
+//        String request_URL = "http://localhost:8042/instances/" + id + "/patient";
+        String request_URL = "http://orthanc:8042/instances/" + id + "/patient";
+
+        RestTemplate restTemplate = new RestTemplate();
+
+        // get api call
+        ResponseEntity<String> response = restTemplate.getForEntity(request_URL, String.class);
+        System.out.println("-----------Response Result------------");
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode resultJson;
+        try {
+            resultJson = objectMapper.readTree(response.getBody());
+        }
+        catch(Exception ex){
+            System.err.println("Error get Response");
+            resultJson = objectMapper.nullNode();
+        }
+        System.out.println(response.toString());
+
+        return resultJson;
+    }
+
+    @GetMapping("/api/patient/{id}/study")
+    public JsonNode patientDicom(@PathVariable String id) throws IOException {
+
+        System.out.println("--------/api/patient/{id}/study GET api Call------------");
+        System.out.println("-----------Param Info------------");
+        System.out.println("Input id: " + id);
+
+//        String request_URL = "http://localhost:8042/tools/find";
+        String request_URL = "http://orthanc:8042/tools/find";
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        RestTemplate restTemplate = new RestTemplate();
+
+        HashMap<String,Object> param = new HashMap<>();
+        JsonNode query = objectMapper.readTree("{\"PatientID\":\"" + id + "\"}");
+        param.put("Expand", true);
+        param.put("Full", true);
+        param.put("Level", "Study");
+        param.put("Query", query);
+
+        // header setting
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        // post api call
+        HttpEntity<Map<String,Object>> requestEntity = new HttpEntity<>(param, headers);
+        ResponseEntity<String> response = restTemplate.postForEntity(request_URL, requestEntity, String.class);
+
+        System.out.println("-----------Response Result------------");
+        JsonNode jsonNode;
+        try {
+            jsonNode = objectMapper.readTree(response.getBody());
+        }
+        catch(Exception ex){
+            System.err.println("Error get Response");
+            jsonNode = objectMapper.readTree(response.toString());
+        }
+        System.out.println(response.toString());
+
+        // parsing StudyInstanceUID
+        ArrayNode arrayNode = (ArrayNode) jsonNode;
+        List<JsonNode> list = new ArrayList<JsonNode>();
+
+        Iterator<JsonNode> itr = arrayNode.elements();
+        while( itr.hasNext() ) {
+            Iterator<JsonNode> in_itr = itr.next().get("MainDicomTags").elements();
+            while( in_itr.hasNext() ){
+                JsonNode field = in_itr.next();
+                if (field.get("Name").asText().equals("StudyInstanceUID")){
+                    list.add(field.get("Value"));
+                    break;
+                }
+            }
+        }
+        return objectMapper.valueToTree(list);
     }
 
     @PostMapping("/api")

--- a/server/DSMP/src/main/resources/templates/index.mustache
+++ b/server/DSMP/src/main/resources/templates/index.mustache
@@ -1,17 +1,32 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-    <title>Hi</title>
+    <title>Dicom API Test</title>
 </head>
 
 <body>
-<form action="/Dicom/3fb6fc01-4ca0db35-dff6d53b-232b607d-1608a2e5" method="get">
-    <button type="submit">다운로드 버튼</button>
+
+<form action="/api/patient/00000003/dicom" method="get">
+    <button type="submit">Patient ID로 다운로드</button>
 </form>
+
+<br>
+
+<form action="/api/patient/00000003/study" method="GET" enctype="text/plain">
+    <button type="submit">Study UID GET by PatientID</button>
+</form>
+
+<br>
+
+<form action="/api/dicom/3fb6fc01-4ca0db35-dff6d53b-232b607d-1608a2e5" method="get">
+    <button type="submit">파일 하나 다운로드</button>
+</form>
+
+<br>
 
 <form action="/api/dicom" method="POST" enctype="multipart/form-data">
     <input type='file' name='dicomfile'/>
-    <button type="submit">업로드 버튼</button>
+    <button type="submit">업로드</button>
 </form>
 
 </body>


### PR DESCRIPTION
Feat: Add Backend API- Return Study ID list by PatientID

1. 전달받는 PatientID가 dicom파일의 PatientID이므로 orthanc의 PatientID로 변환해야한다. 그래서 orthanc API를 통해 변환을 한번해주어야한다. 

2. 전환된 orthanc의 PatientID를 이용하여 StudyID가 포함된 Response를 받아온다.

3. Response에서 StudyID만을 추출하여 Json으로 반환한다.