### PR TITLE
Feat : 방문자 삭제 API 세분화

### DIFF
--- a/server/DSMP/src/main/java/com/knuipalab/dsmp/controller/project/api/ProjectApiController.java
+++ b/server/DSMP/src/main/java/com/knuipalab/dsmp/controller/project/api/ProjectApiController.java
@@ -51,10 +51,17 @@ public class ProjectApiController {
         projectService.invite(projectId,projectInviteRequestDto);
     }
 
-    //poject 방문자 삭제
-    @PutMapping ("api/Project/{projectId}/oust")
+    //poject 방문자 삭제 리스트
+    @PutMapping ("api/Project/{projectId}/oust/list")
     public void oust(@PathVariable String projectId ,@RequestBody ProjectOustRequestDto projectOustRequestDto){
-        projectService.oust(projectId,projectOustRequestDto);
+        projectService.oustByEmailList(projectId,projectOustRequestDto);
     }
+
+    //poject 방문자에서 본인 삭제
+    @PutMapping ("api/Project/{projectId}/oust")
+    public void oust(@PathVariable String projectId){
+        projectService.oust(projectId);
+    }
+
 
 }

--- a/server/DSMP/src/main/java/com/knuipalab/dsmp/domain/project/Project.java
+++ b/server/DSMP/src/main/java/com/knuipalab/dsmp/domain/project/Project.java
@@ -50,4 +50,10 @@ public class Project {
                 .collect(Collectors.toList());
     }
 
+    public void oust(String email){
+        this.visitor = this.visitor.stream()
+                .filter(visitor -> !visitor.getEmail().contains(email) )
+                .collect(Collectors.toList());
+    }
+
 }

--- a/server/DSMP/src/main/java/com/knuipalab/dsmp/service/project/ProjectService.java
+++ b/server/DSMP/src/main/java/com/knuipalab/dsmp/service/project/ProjectService.java
@@ -134,7 +134,7 @@ public class ProjectService {
     }
 
     @Transactional
-    public void oust(String projectId, ProjectOustRequestDto projectOustRequestDto) {
+    public void oustByEmailList(String projectId, ProjectOustRequestDto projectOustRequestDto) {
 
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(()->new IllegalArgumentException("해당 projectId 값을 가진 프로젝트 정보가 없습니다."));
@@ -144,4 +144,19 @@ public class ProjectService {
         projectRepository.save(project);
 
     }
+
+    @Transactional
+    public void oust(String projectId) {
+
+        SessionUser sessionUser = (SessionUser)httpSession.getAttribute("user");
+
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(()->new IllegalArgumentException("해당 projectId 값을 가진 프로젝트 정보가 없습니다."));
+
+        project.oust(sessionUser.getEmail());
+
+        projectRepository.save(project);
+
+    }
+
 }


### PR DESCRIPTION
issue : #180

기능 변경 및 추가 :

1.  @PutMapping ("api/Project/{projectId}/oust/list")
 -  일반적으로 프로젝트 생성자가 방문자 삭제 시 사용되며, 생성자는  여러 사용자의 email을 담아 리스트로 보내면, 해당 사용자가 방문자 목록에서 삭제된다.

2.  @PutMapping ("api/Project/{projectId}/oust")
- 본인이 프로젝트 초대 목록에서 나가고 싶을 때 사용하는 api 이다, session을 통해 유저 이메일을 찾아 내  삭제 하는 방식으로 진행하였다.