### PR TITLE
Fix : application.yml mongodb host

### DIFF
--- a/server/DSMP/src/main/resources/application.yml
+++ b/server/DSMP/src/main/resources/application.yml
@@ -5,7 +5,7 @@ spring:
 
   data:
     mongodb:
-      host: mongodb  #local에서는 'localhost', docker server에서는 'mongodb'로 설정
+      host: localhost
       port: 27017
       database: DSMP
       authentication-database: admin
@@ -27,6 +27,9 @@ spring:
   config:
     activate:
       on-profile: prod
+  data:
+    mongodb:
+      host: mongodb
 hostLocation : imdc.hopto.org
 ---
 spring:


### PR DESCRIPTION
local로 프로파일 설정시 mongodb의 호스트는 localhost로 정해져야 하지만
mongodb를 가르키는 버그를 수정, 이제 다른 컨테이너를 실행하고 인텔리제이에서
로컬로 Spring 프로젝트를 실행하면서 개발이 가능하다.